### PR TITLE
API: Update normal shaper drop rates with new values from wiki

### DIFF
--- a/api/poe_profit_calc/bossing/bosses.py
+++ b/api/poe_profit_calc/bossing/bosses.py
@@ -371,7 +371,7 @@ TheShaper = Boss(
         BossItem(
             "Dying Sun",
             "DyingSun",
-            0.01,
+            0.03,
             Matcher(PoeNinjaEndpoint.UNIQUE_FLASK, "Dying Sun"),
         ),
         BossItem(

--- a/api/poe_profit_calc/bossing/bosses.py
+++ b/api/poe_profit_calc/bossing/bosses.py
@@ -359,13 +359,13 @@ TheShaper = Boss(
         BossItem(
             "Voidwalker",
             "Voidwalker",
-            0.33,
+            0.26,
             Matcher(PoeNinjaEndpoint.UNIQUE_ARMOUR, "Voidwalker"),
         ),
         BossItem(
             "Solstice Vigil",
             "SolsticeVigil",
-            0.1,
+            0.15,
             Matcher(PoeNinjaEndpoint.UNIQUE_ACCESSORY, "Solstice Vigil"),
         ),
         BossItem(


### PR DESCRIPTION
Shaper:
* Dying Sun droprate 0.01 -> 0.03
* Voidwalker 0.33 -> 0.26
* Solstice Vigil 0.1 -> 0.15

<img width="702" height="150" alt="image" src="https://github.com/user-attachments/assets/8ca3a103-9de4-4745-aa45-66618fae5287" />

Updating these based on wiki, unless you were using a different source?